### PR TITLE
v0.0.7 [BETA] Hotfix Lace wallet connection (issue #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unfrackit",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/App.vue
+++ b/src/App.vue
@@ -219,7 +219,7 @@
         <v-card-title>Connect Your Wallet</v-card-title>
         <v-card-text>
           <v-btn v-for="wallet in cardano.Wallets" :key="wallet.name" block class="wallet-btn mb-2 text-start" x-large
-                 @click="connectTo(wallet)" :loading="wallet.loading">
+                 @click="connectTo(wallet)" :loading="!!walletLoading[wallet.name]">
             <v-img :src="wallet.icon" max-width="24" height="24" class="me-2" contain :alt="wallet.name"></v-img>
             Connect {{ wallet.name.replace(" Wallet", "") }}
           </v-btn>
@@ -354,6 +354,7 @@ export default {
   data: () => ({
     version: version,
     connectModal: false,
+    walletLoading: {},
     analyzingUTxO: false,
     gettingUTxO: false,
     stakeKey: null,
@@ -396,11 +397,29 @@ export default {
         allowOutsideClick: false
       });
     },
+    describeConnectError(e) {
+      const msg = (e && (e.info || e.message)) || String(e);
+      // Wallets that freeze their CIP-30 API object (e.g. Lace) throw a TypeError
+      // when the dApp tries to write a property onto the wallet handle.
+      if (/not extensible|frozen|read.?only/i.test(msg)) {
+        return `This wallet's API is locked down and rejected the connection. Try reloading the page; if the problem persists, please report it.`;
+      }
+      // CIP-30 APIError codes: -1 InvalidRequest, -2 InternalError, -3 Refused, -4 AccountChange
+      if (e && e.code === -3) {
+        return `The wallet declined the connection request. Please approve it in the wallet popup and try again.`;
+      }
+      if (e && e.code === -1) {
+        return `The wallet reported an invalid connection request.`;
+      }
+      return `Could not connect: ${msg}. Make sure a dApp account is selected and the wallet is unlocked.`;
+    },
     async connectTo(wallet) {
+      this.$set(this.walletLoading, wallet.name, true);
       try {
         await this.connect(wallet);
       } catch (e) {
-        this.showError(`Could not connect to your wallet? Make sure you have a dApp account selected!`);
+        this.$set(this.walletLoading, wallet.name, false);
+        this.showError(this.describeConnectError(e));
         return;
       }
 
@@ -414,6 +433,7 @@ export default {
         this.changeAddress = await this.getChangeAddress();
       } catch (e) {
         console.error("Could not fetch the wallet's change address?");
+        this.$set(this.walletLoading, wallet.name, false);
         return;
       }
 
@@ -425,6 +445,7 @@ export default {
       } catch (e) {
         console.error("Could not detect the wallet's connected network?");
       }
+      this.$set(this.walletLoading, wallet.name, false);
       this.connectModal = false;
       await this.checkWalletBalance();
     },

--- a/src/plugins/vue-cardano.js
+++ b/src/plugins/vue-cardano.js
@@ -211,7 +211,6 @@ export default {
                     });
                 },
                 async connect(wallet) {
-                    wallet.loading = true;
                     try {
                         this.cardano.ActiveWallet = wallet;
                         this.cardano.Wallet = await wallet.enable();
@@ -219,9 +218,7 @@ export default {
                         await this.getChangeAddress();
                         this.cardano.stake_key = await this.getStakeKey();
                         this.$emit("connected");
-                        wallet.loading = false;
                     } catch (e) {
-                        wallet.loading = false;
                         console.error("Connection Error:", e);
                         throw e;
                     }

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "Major": 0,
   "Minor": 0,
-  "Revision": 6,
+  "Revision": 7,
   "Tag": "BETA"
 }


### PR DESCRIPTION
stop mutating the CIP-30 API object and surface connection errors that actually mean something.

Lace deep-freezes the `window.cardano` API object it exposes to dApps as a security measure, which means setting `wallet.loading = true` from inside `connect()` throws a TypeError before we ever get to `wallet.enable()`. Users just saw the generic "Make sure you have a dApp account selected!" toast and had no way to actually connect.

Updates include:

- Move per-button loading state off the CIP-30 wallet handle and into a `walletLoading` map on App.vue's data, keyed by `wallet.name`. The mixin's `connect()` no longer writes anything to the wallet object - reads only.
- Replace the single hardcoded connect error string with a `describeConnectError` classifier that pattern-matches the frozen-object TypeError Lace throws, the CIP-30 APIError codes (-3 user refused, -1 invalid request), and otherwise surfaces the underlying error message so we can actually see what went wrong next time.
- Bump version to 0.0.7 [BETA] in `package.json` and `src/version.json`.